### PR TITLE
Don't use SFX/MFX/EFX

### DIFF
--- a/DeviceAPOInfo.h
+++ b/DeviceAPOInfo.h
@@ -41,13 +41,14 @@ public:
 	std::wstring deviceGuid;
 	std::wstring originalLfxGuid;
 	std::wstring originalGfxGuid;
+	std::wstring originalSfxGuid;
+	std::wstring originalMfxGuid;
+	std::wstring originalEfxGuid;
 	bool isInput;
 	bool isInstalled;
 	bool isLFX;
-	bool isAPO2;
 	bool isDual;
-	bool installAsAPO2;
 
 private:
-	bool tryAPOGuid(const std::wstring& keyPath, const std::wstring& valueName, GUID guid, bool lfx, bool apo2);
+	bool tryAPOGuid(const std::wstring& keyPath, const std::wstring& valueName, GUID guid, bool lfx);
 };


### PR DESCRIPTION
because it doesn't work
## communication streams don't call mfx

we have to use gfx instead of mfx for post-mix because communication streams don't call mfx, they only call efx

> http://download.microsoft.com/download/7/C/1/7C1C33EC-748A-477D-B250-6D90A0E0AA08/Lync%20and%20Skype%20Audio%20Offloading%20of%20Digital%20Signal%20Processing%20Effects%20in%20Windows%208-1.pdf
> 
> In Windows 8.1, a render audio stream opened in communications category is always opened in raw mode. Any must-have effect, such as speaker protection, must be implemented as an endpoint effect (EFX), which is an always-on effect.

by disabling sfx/mfx/efx everything fall back to lfx/gfx. including modern skype
## better than using sfx/mfx/efx

this is better than using sfx/mfx for pre-mix and efx for post-mix because
- the sfx/mfx/efx result is identical at best to lfx/gfx because EqualizerAPO dont use any APOInitSystemEffects2 features
- we don't know which of sfx/mfx/efx are pre-mix and post-mix because there's almost no docs or samples for it. capture devices have no gfx. we don't know which of sfx/mfx/efx it has
- sfx or mfx for pre-mix together with efx for post-mix fail. the audio playback is silent and create this endless Initialize loop https://www.dropbox.com/s/ghrh2ij0di3wd8m/EqualizerAPO.log?dl=0. my config.txt is
  
  ```
  Preamp: -30 dB
  ```
## svn commit

commit in svn with

```
curl https://github.com/mirror/equalizerapo/pull/1.diff > patch.diff
patch -p1 < patch.diff
```

copy the commit message from https://github.com/mirror/equalizerapo/pull/1/commits

set me as author so my commit can be associated with my account here and at openhub.net

```
svn propset --revprop svn:author 'John Sebastian Peterson <john.s.peterson@live.com>'
```
## merge my patch

i created a pull request at https://github.com/mirror/equalizerapo/pull/1
## sourceforge notification

a pull request notification is at https://sourceforge.net/p/equalizerapo/tickets/3/
